### PR TITLE
Better log level handling within micro

### DIFF
--- a/changelog/unreleased/log-level-handling.md
+++ b/changelog/unreleased/log-level-handling.md
@@ -1,0 +1,7 @@
+Change: Better log level handling within micro
+
+Currently every log message from the micro internals are logged with the info
+level, we really need to respect the proper defined log level within our log
+wrapper package.
+
+https://github.com/owncloud/ocis-pkg/issues/2


### PR DESCRIPTION
Currently every log message from the micro internals are logged with the info
level, we really need to respect the proper defined log level within our log
wrapper package.

Fixes #2