### PR TITLE
Only execute go build -i on darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,18 @@ SHELL := bash
 NAME := ocis-pkg
 IMPORT := github.com/owncloud/$(NAME)
 
+ifeq ($(OS), Windows_NT)
+	UNAME := Windows
+else
+	UNAME := $(shell uname -s)
+endif
+
+ifeq ($(UNAME), Darwin)
+	GOBUILD ?= go build -i
+else
+	GOBUILD ?= go build
+endif
+
 PACKAGES ?= $(shell go list ./...)
 SOURCES ?= $(shell find . -name "*.go" -type f)
 GENERATE ?= $(PACKAGES)
@@ -52,4 +64,4 @@ test:
 
 .PHONY: build
 build:
-	go build -i -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./...
+	$(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./...


### PR DESCRIPTION
As some linux systems don't like the -i flag for go build we are
generally disabling that by default, you can always enable it by
overwriting GOBUILD.

