### PR TITLE
Require a minimum of Go 1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Just import the required packages within your ownCloud Infinite Scale extensions
 
 ## Development
 
-Make sure you have a working Go environment, for further reference or a guide take a look at the [install instructions](http://golang.org/doc/install.html). This project requires Go >= v1.12.
+Make sure you have a working Go environment, for further reference or a guide take a look at the [install instructions](http://golang.org/doc/install.html). This project requires Go >= v1.13.
 
 ```console
 git clone https://github.com/owncloud/ocis-pkg.git


### PR DESCRIPTION
Some dependencies of the ocis extensions require crypto/ed25519 which
doesn't seem to be available in Go 1.12.

