### PR TITLE
fix serving static issues

### DIFF
--- a/middleware/static.go
+++ b/middleware/static.go
@@ -8,8 +8,12 @@ import (
 
 // Static is a middleware that serves static assets.
 func Static(root string, fs http.FileSystem) func(http.Handler) http.Handler {
+	if !strings.HasSuffix(root, "/") {
+		root = root + "/"
+	}
+
 	static := http.StripPrefix(
-		root+"/",
+		root,
 		http.FileServer(
 			fs,
 		),


### PR DESCRIPTION
ocis-hello uses `"/"` as root. adding another `/` causes the static middleware to always fail stripping that prefix. all requests will return 404.

setting root to `""` in the ocis-hello flag does not work because the chi dies screaming that routes need to start with a `/`.

`path.Clean(root+"/")` would yield `""` for root=`"/"`

so I think this is the correct fix. unless we want to safeguard against an admin trying to use .. in the assets path, which should be permitted IMO.

