### PR TITLE
Report trace on a single service basis

### DIFF
--- a/middleware/tracing.go
+++ b/middleware/tracing.go
@@ -14,9 +14,14 @@ func Trace(next http.Handler) http.Handler {
 		var span *trace.Span
 
 		tc := tracecontext.HTTPFormat{}
-		sc, ok := tc.SpanContextFromRequest(r)
-		if ok {
+		// reconstruct span context from request
+		if sc, ok := tc.SpanContextFromRequest(r); ok {
+			// if there is one, add it to the new span
 			ctx, span = trace.StartSpanWithRemoteParent(r.Context(), r.URL.String(), sc)
+			defer span.End()
+		} else {
+			// create a new span if there is no context
+			ctx, span = trace.StartSpan(r.Context(), r.URL.String())
 			defer span.End()
 		}
 

--- a/middleware/tracing.go
+++ b/middleware/tracing.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 
 	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
@@ -10,7 +11,7 @@ import (
 // Trace unpacks the request context looking for an existing trace id.
 func Trace(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
+		var ctx context.Context
 		var span *trace.Span
 
 		tc := tracecontext.HTTPFormat{}


### PR DESCRIPTION
A service can report traces regardless there this can be reconstructed from the context or not