### PR TITLE
Add publishing to GH step without building binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 SHELL := bash
 NAME := ocis-pkg
 IMPORT := github.com/owncloud/$(NAME)
+BIN := bin
+DIST := dist
 
 ifeq ($(OS), Windows_NT)
 	UNAME := Windows
@@ -33,6 +35,7 @@ sync:
 .PHONY: clean
 clean:
 	go clean -i ./...
+	rm -rf $(BIN) $(DIST)
 
 .PHONY: fmt
 fmt:

--- a/changelog/CHANGELOG.tmpl
+++ b/changelog/CHANGELOG.tmpl
@@ -1,18 +1,43 @@
-{{- range $changes := . }}{{ with $changes -}}
-# Changelog for {{ .Version }}
+{{ $allVersions := . }}
+{{- range $index, $changes := . }}{{ with $changes -}}
+{{ if gt (len $allVersions) 1 -}}
+# Changelog for [{{ .Version }}] ({{ .Date }})
 
-The following sections list the changes for {{ .Version }}.
+The following sections list the changes in ocis-pkg {{ .Version }}.
+
+{{/* creating version compare links */ -}}
+{{ $next := add1 $index -}}
+{{ if ne (len $allVersions) $next -}}
+{{ $previousVersion := (index $allVersions $next).Version -}}
+{{ if eq .Version "unreleased" -}}
+[{{ .Version }}]: https://github.com/owncloud/ocis-pkg/compare/v{{ $previousVersion }}...master
+
+{{ else -}}
+[{{ .Version }}]: https://github.com/owncloud/ocis-pkg/compare/v{{ $previousVersion }}...v{{ .Version }}
+
+{{ end -}}
+{{ end -}}
+
+{{- /* last version managed by calens, end of the loop */ -}}
+{{ if eq .Version "1.0.0" -}}
+[{{ .Version }}]: https://github.com/owncloud/ocis-pkg/compare/63fa90a673cbc3238a503ea5e6304f1db7fdf47b...v{{ .Version }}
+
+{{ end -}}
+{{ else -}}
+# Changes in {{ .Version }}
+
+{{ end -}}
 
 ## Summary
 {{ range $entry := .Entries }}{{ with $entry }}
- * {{ .TypeShort }} #{{ .PrimaryID }}: {{ .Title }}
+* {{ .Type }} - {{ .Title }}: [#{{ .PrimaryID }}]({{ .PrimaryURL }})
 {{- end }}{{ end }}
 
 ## Details
 {{ range $entry := .Entries }}{{ with $entry }}
- * {{ .Type }} #{{ .PrimaryID }}: {{ .Title }}
+* {{ .Type }} - {{ .Title }}: [#{{ .PrimaryID }}]({{ .PrimaryURL }})
 {{ range $par := .Paragraphs }}
-   {{ wrap $par 80 3 }}
+   {{ wrapIndent $par 80 3 }}
 {{ end -}}
 {{ range $url := .IssueURLs }}
    {{ $url -}}
@@ -23,6 +48,6 @@ The following sections list the changes for {{ .Version }}.
 {{ range $url := .OtherURLs }}
    {{ $url -}}
 {{ end }}
-{{ end }}{{ end }}
 
+{{ end }}{{ end -}}
 {{ end }}{{ end -}}

--- a/changelog/unreleased/tracing-middleware.md
+++ b/changelog/unreleased/tracing-middleware.md
@@ -1,4 +1,4 @@
-Feature: Tracing middleware
+Enhancement: Tracing middleware
 
 A new tracing middleware has been added to unpack context propagation
 


### PR DESCRIPTION
# Description
- This repo doesn't build binaries
- We only create tags and a changelog

## This PR adds
- A publishing step which creates a GH release item for each tag with the Changes for that version in the description.
- Version compare links for each GH tag
- Run the changelog step on every pr to check for correct syntax
- It will not build release artifacts