### PR TITLE
add header to access-control-allow-headers

### DIFF
--- a/changelog/unreleased/add-header-to-cors-handler.md
+++ b/changelog/unreleased/add-header-to-cors-handler.md
@@ -1,0 +1,5 @@
+Change: Add header to cors handler 
+
+The `x-requested-with` header was added to allow ajax requests.
+
+https://github.com/owncloud/ocis-pkg/issues/41

--- a/middleware/header.go
+++ b/middleware/header.go
@@ -24,7 +24,7 @@ func Cors(next http.Handler) http.Handler {
 		} else {
 			w.Header().Set("Access-Control-Allow-Origin", "*")
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "authorization, origin, content-type, accept")
+			w.Header().Set("Access-Control-Allow-Headers", "authorization, origin, content-type, accept, x-requested-with")
 			w.Header().Set("Allow", "HEAD, GET, POST, PUT, PATCH, DELETE, OPTIONS")
 
 			w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
The `x-requested-with` header was added to allow ajax requests.

Closes #41 