### PR TITLE
Add ocis-proxy reference and comment

### DIFF
--- a/middleware/account.go
+++ b/middleware/account.go
@@ -46,6 +46,8 @@ func ExtractAccountUUID(opts ...account.Option) func(http.Handler) http.Handler 
 				return
 			}
 
+			// Important: user.Id.OpaqueId is the AccountUUID. Set this way in the account uuid middleware in ocis-proxy.
+			// https://github.com/owncloud/ocis-proxy/blob/ea254d6036592cf9469d757d1295e0c4309d1e63/pkg/middleware/account_uuid.go#L109
 			ctx := context.WithValue(r.Context(), UUIDKey, user.Id.OpaqueId)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})


### PR DESCRIPTION
Add ocis-proxy reference and comment, explaining that opaqueId = account uuid

Just for clarity in the code. Looks confusing that we're setting an opaqueId, when it's really the account uuid.