### PR TITLE
add `ocis.id` and numeric id claims

### DIFF
--- a/changelog/unreleased/add-ocisid-claim.md
+++ b/changelog/unreleased/add-ocisid-claim.md
@@ -1,0 +1,7 @@
+Enhancement: add `ocis.id` and numeric id claims
+
+We added an `ocis.id` claim to the OIDC standard claims. It allows the idp to send a stable identifier that can be exposed to the outside world (in contrast to sub, which might change whens the IdP changes).
+
+In addition we added `uidnumber` and `gidnumber` claims, which can be used by the IdP as well. They will be used by storage providers that integrate with an existing LDAP server.
+
+https://github.com/owncloud/ocis-pkg/pull/50

--- a/oidc/claims.go
+++ b/oidc/claims.go
@@ -170,4 +170,14 @@ type StandardClaims struct {
 	// TODO add address claim https://openid.net/specs/openid-connect-core-1_0.html#AddressClaim
 	Address    map[string]interface{} `json:"address,omitempty"`
 	KCIdentity map[string]string      `json:"kc.identity,omitempty"`
+
+	// To integrate with an existing LDAP server the IdP can send the numeric user and group id:
+
+	// UIDNumber is a unique numerical id that will be used when setting acls on a storage that integrates with the OS/LDAP
+	UIDNumber string `json:"uidnumber,omitempty"`
+	// GIDNumber is a unique numerical id that will be used when setting acls on a storage that integrates with the OS/LDAP
+	GIDNumber string `json:"gidnumber,omitempty"`
+
+	// OcisID is a unique, persistent, non reassignable user id
+	OcisID string `json:"ocis.id,omitempty"`
 }


### PR DESCRIPTION
We added an `ocis.id` claim to the OIDC standard claims. It allows the idp to send a stable identifier that can be exposed to the outside world (in contrast to sub, which might change whens the IdP changes).